### PR TITLE
Leave logger setup of the library on the clients

### DIFF
--- a/bin/dock-pulp-restore.py
+++ b/bin/dock-pulp-restore.py
@@ -22,7 +22,7 @@ import sys
 
 import dockpulp
 
-log = dockpulp.log
+log = dockpulp.setup_logger(dockpulp.log)
 
 def get_opts():
     usage="""%prog [options] environment config.json

--- a/bin/dock-pulp.py
+++ b/bin/dock-pulp.py
@@ -24,7 +24,8 @@ import sys
 
 import dockpulp
 
-log = dockpulp.log
+
+log = dockpulp.setup_logger(dockpulp.log)
 
 def main():
     usage = """CLI for Pulp instances providing Docker content

--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -36,9 +36,22 @@ import imgutils
 C_TYPE = 'docker_image'         # pulp content type identifier for docker
 HIDDEN = 'redhat-everything'    # ID of a "hidden" repository for RCM
 
-log = logging.getLogger('dockpulp')
-log.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stdout, format='%(levelname)-9s %(message)s')
+
+# Setup our logger
+# Null logger to avoid spurious messages, add a handler in app code
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
+# This is our log object, clients of this library can use this object to
+# define their own logging needs
+log = logging.getLogger("dockpulp")
+
+# Add the null handler
+h = NullHandler()
+log.addHandler(h)
+
 
 class Pulp(object):
     def __init__(self, env='qa'):
@@ -560,3 +573,9 @@ class Pulp(object):
 def split_content_url(url):
     i = url.find('/content')
     return url[:i], url[i:]
+
+
+def setup_logger(log):
+    log.setLevel(logging.INFO)
+    logging.basicConfig(stream=sys.stdout)
+    return log


### PR DESCRIPTION
Library should provide only the logger with empty logging handler. It is
up to clients to setup logging any way they wants to. Also with the
current way how logging was initialised it changed global logger.

See https://docs.python.org/3.1/library/logging.html#library-config for
detailed explanation.

Resolves: #1