### PR TITLE
Fix mkdir typo in code which created ~/.pulp dir

### DIFF
--- a/bin/dock-pulp.py
+++ b/bin/dock-pulp.py
@@ -356,7 +356,7 @@ def do_login(bopts, bargs):
     p.login(opts.username, opts.password)
     creddir = os.path.expanduser('~/.pulp')
     if not os.path.exists(creddir):
-        os.makedir(creddir)
+        os.makedirs(creddir)
     shutil.copy(p.certificate, creddir)
     shutil.copy(p.key, creddir)
     log.info('Credentials stored in %s.' % creddir)


### PR DESCRIPTION
Running login command caused the problems:

    $ dock-pulp.py -s myserver login -u admin -p $(PASS)
    INFO      logging in as admin
    Traceback (most recent call last):
    File ".../dockpulp/bin/dock-pulp.py", line 6, in <module>
        exec(compile(open(__file__).read(), __file__, 'exec'))
    File ".../dockpulp/bin/dock-pulp.py", line 596, in <module>
        main()
    File ".../dockpulp/bin/dock-pulp.py", line 47, in main
        cmd(opts, args[1:])
    File ".../dockpulp/bin/dock-pulp.py", line 361, in do_login
        os.makedir(creddir)
    AttributeError: 'module' object has no attribute 'makedir'