### PR TITLE
fix login method

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -514,6 +514,7 @@ class Pulp(object):
                 fd.write(blob[part])
                 fd.close()
                 setattr(self._request, part, f)
+                setattr(self, part, f)
             atexit.register(self._cleanup, sessiondir)
 
     def logout(self):


### PR DESCRIPTION
otherwise it ends with traceback b/c certificate attribute is not set:

```shell
dock-pulp login -u ... -p ...
Traceback (most recent call last):
  File "/bin/dock-pulp.py", line 8, in <module>
    execfile(__file__)
  File "/root/dockpulp/bin/dock-pulp.py", line 673, in <module>
    main()
  File "/root/dockpulp/bin/dock-pulp.py", line 49, in main
    cmd(opts, args[1:])
  File "/root/dockpulp/bin/dock-pulp.py", line 383, in do_login
    shutil.copy(p.certificate, creddir)
  File "/usr/lib64/python2.7/shutil.py", line 118, in copy
    dst = os.path.join(dst, os.path.basename(src))
  File "/usr/lib64/python2.7/posixpath.py", line 121, in basename
    i = p.rfind('/') + 1
AttributeError: 'NoneType' object has no attribute 'rfind'
```