### PR TITLE
Don't install dockpulp.conf in /etc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     package_dir = {'': '.'},
     packages = ['dockpulp'],
     scripts = ['bin/dock-pulp.py', 'bin/dock-pulp-bootstrap.py', 'bin/dock-pulp-restore.py'],
-    data_files = [('/etc', ['conf/dockpulp.conf'])],
+    package_data = {'': ['conf/dockpulp.conf']},
 )


### PR DESCRIPTION
Example config files are meant to be in package_data, not data_files. Installing to `/etc` means they can't be `pip install`ed in a non-privileged environment such as Travis CI.

See https://github.com/DBuildService/atomic-reactor/issues/209 for the reason behind this change.