### PR TITLE
Add simplejson as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@
 import sys
 from setuptools import setup, Command
 
+def _simplejson_on_python26():
+    if (sys.version_info[0] > 2 or
+        (sys.version_info[0] == 2 and
+         sys.version_info[1] > 6)):
+        return []
+    return ['simplejson']
+
 setup(
     name = "dockpulp",
     version = "1.11",
@@ -12,6 +19,7 @@ setup(
     url = "https://github.com/release-engineering/dockpulp.git",
     package_dir = {'': '.'},
     packages = ['dockpulp'],
+    install_requires = _simplejson_on_python26(),
     scripts = ['bin/dock-pulp.py', 'bin/dock-pulp-bootstrap.py', 'bin/dock-pulp-restore.py'],
     package_data = {'': ['conf/dockpulp.conf']},
 )


### PR DESCRIPTION
The project requires `simplejson`, which may not be installed. Here is one approach for handling that: deal with it in `setup.py`.

The other approach would be to use `json` instead of `simplejson`.