### PR TITLE
Require simplejson on Python 2.6

### DIFF
--- a/bin/dock-pulp-restore.py
+++ b/bin/dock-pulp-restore.py
@@ -17,8 +17,17 @@
 from optparse import OptionParser
 import os.path
 import requests
-import simplejson as json
 import sys
+
+try:
+    # Python 2.6 and earlier
+    import simplejson as json
+except ImportError:
+    if sys.version_info[0] > 2 or sys.version_info[1] > 6:
+        import json
+    else:
+        # json on python 2.6 does not behave like simplejson
+        raise
 
 import dockpulp
 

--- a/bin/dock-pulp.py
+++ b/bin/dock-pulp.py
@@ -19,8 +19,17 @@ from optparse import OptionParser
 import os
 import requests
 import shutil
-import simplejson as json
 import sys
+
+try:
+    # Python 2.6 and earlier
+    import simplejson as json
+except ImportError:
+    if sys.version_info[0] > 2 or sys.version_info[1] > 6:
+        import json
+    else:
+        # json on python 2.6 does not behave like simplejson
+        raise
 
 import dockpulp
 

--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -28,10 +28,14 @@ import time
 import multiprocessing
 
 try:
-    import json
-except ImportError:
     # Python 2.6 and earlier
     import simplejson as json
+except ImportError:
+    if sys.version_info[0] > 2 or sys.version_info[1] > 6:
+        import json
+    else:
+        # json on python 2.6 does not behave like simplejson
+        raise
 
 import errors
 import imgutils

--- a/dockpulp/imgutils.py
+++ b/dockpulp/imgutils.py
@@ -16,7 +16,16 @@
 import contextlib
 import os
 import tarfile
-import simplejson as json
+
+try:
+    # Python 2.6 and earlier
+    import simplejson as json
+except ImportError:
+    if sys.version_info[0] > 2 or sys.version_info[1] > 6:
+        import json
+    else:
+        # json on python 2.6 does not behave like simplejson
+        raise
 
 # see https://github.com/pulp/pulp_docker/blob/master/common/pulp_docker/common/tarutils.py
 


### PR DESCRIPTION
For Python > 2.6, just prefer it.

This is based on https://github.com/release-engineering/dockpulp/pull/12#issuecomment-119216836 "Rats. I have to switch that around."