### PR TITLE
Fix push_to_pulp with a repo_prefix

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -570,7 +570,8 @@ class Pulp(object):
                 #print kwargs
             self.createRepo(repo, "/pulp/docker/%s" % repo,
                             registry_id=mod_repos_tags_mapping[repo]["registry-id"],
-                            desc=kwargs.get("desc"), title=kwargs.get("title"))
+                            desc=kwargs.get("desc"), title=kwargs.get("title"),
+                            prefix_with=repo_prefix)
 
         top_layer = imgutils.get_top_layer(pulp_md)
         self.upload(tarfile)


### PR DESCRIPTION
The prefix was not passed to createRepo which then created repo `redhat-$repo_prefix-$reponame` instead of `$repo_prefix-$reponame`.
This subsequently caused 404 error in `/pulp/api/v2/repositories/$repo_prefix-$reponame/actions/associate/`.
