### PR TITLE
Don't use logging.basicConfig, set handler to the logger instance

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -767,5 +767,9 @@ def split_content_url(url):
 
 def setup_logger(log):
     log.setLevel(logging.INFO)
-    logging.basicConfig(stream=sys.stdout, format='%(levelname)-9s %(message)s')
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(levelname)-9s %(message)s')
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
     return log


### PR DESCRIPTION
Using logging.basicConfig adds a handler to the root config, which means it duplicates all messages when dockpulp is imported in atomic reactor and logging is set.
Also, I think this should fix https://github.com/projectatomic/atomic-reactor/issues/271, but I'm not sure and would like to ask you to test that.