### PR TITLE
don't tback when server is not specified

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -595,7 +595,7 @@ class Pulp(object):
                 raise errors.DockPulpConfigError('Missing section: %s' % sect)
             if not conf.has_option(sect, self.env):
                 raise errors.DockPulpConfigError('%s section is missing %s' %
-                    (sect, env))
+                    (sect, self.env))
             process_f = getattr(self, process)
             ret = process_f(conf.items(sect))
             if target:


### PR DESCRIPTION
```
$ dock-pulp login -u user -p pswd
Traceback (most recent call last):
  File "/usr/bin/dock-pulp", line 723, in <module>
    main()
  File "/usr/bin/dock-pulp", line 58, in main
    cmd(opts, args[1:])
  File "/usr/bin/dock-pulp", line 392, in do_login
    p = dockpulp.Pulp(env=bopts.server, config_file=bopts.config_file)
  File "/usr/lib/python2.7/site-packages/dockpulp/__init__.py", line 157, in __init__
    self.load_configuration(config_file)
  File "/usr/lib/python2.7/site-packages/dockpulp/__init__.py", line 598, in load_configuration
    (sect, env))
NameError: global name 'env' is not defined
```