### PR TITLE
Don't traceback on incomplete distributor config

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -547,10 +547,16 @@ class Pulp(object):
                 'description': blob['description'],
                 'title': blob['display_name']
             }
-            if len(blob['distributors']) > 0:
-                r['protected'] = blob['distributors'][0]['config']['protected']
-                r['redirect'] = blob['distributors'][0]['config']['redirect-url']
-                r['docker-id'] = blob['distributors'][0]['config']['repo-registry-id']
+            try:
+                if len(blob['distributors']) > 0:
+                    r['protected'] = blob['distributors'][0]['config']['protected']
+                    r['redirect'] = blob['distributors'][0]['config']['redirect-url']
+                    r['docker-id'] = blob['distributors'][0]['config']['repo-registry-id']
+            except KeyError:
+                log.debug("ignoring repo-id %s, incomplete distributor config",
+                          r['id'])
+                continue
+
             if content:
                 data = {
                     'criteria': {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/dock-pulp.py", line 4, in <module>
    __import__('pkg_resources').run_script('dockpulp==1.11', 'dock-pulp.py')
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 735, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1659, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/lib/python2.7/site-packages/dockpulp-1.11-py2.7.egg/EGG-INFO/scripts/dock-pulp.py", line 678, in <module>
    
  File "/usr/lib/python2.7/site-packages/dockpulp-1.11-py2.7.egg/EGG-INFO/scripts/dock-pulp.py", line 58, in main
    
  File "/usr/lib/python2.7/site-packages/dockpulp-1.11-py2.7.egg/EGG-INFO/scripts/dock-pulp.py", line 343, in do_list
    
  File "build/bdist.linux-x86_64/egg/dockpulp/__init__.py", line 551, in listRepos
KeyError: 'protected'
```