### PR TITLE
Don't override the default port for sync

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -705,9 +705,6 @@ class Pulp(object):
         repoid = repoinfo[0]['docker-id']
 
         syncenv = self.syncenv
-        if ':' not in syncenv:
-            syncenv += ":5000"
-
         data = {
             'override_config': {
                 'ssl_validation': False,


### PR DESCRIPTION
This is needed so that 'https://distribution.example.com' doesn't have to be written as 'https://distribution.example.com:443'.