### PR TITLE
Don't require redirect-url to be set

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -550,7 +550,6 @@ class Pulp(object):
             try:
                 if len(blob['distributors']) > 0:
                     r['protected'] = blob['distributors'][0]['config']['protected']
-                    r['redirect'] = blob['distributors'][0]['config']['redirect-url']
                     r['docker-id'] = blob['distributors'][0]['config']['repo-registry-id']
             except KeyError:
                 log.debug("ignoring repo-id %s, incomplete distributor config",


### PR DESCRIPTION
If redirect-url is set, the only way to support both V1 and V2 content at the same time is to set a symlink in the filer, as the repository name is directly appended to the redirect-url.

With no redirect-url set, Crane will append `/v1/{repository}` or `/v2/{repository}` depending on the API version used to access it.

By allowing redirect-url to be omitted, we can use default-config Pulp installations without issue for V1 and V2 content.