### PR TITLE
Continue if there is no distributor for a repo

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -568,11 +568,14 @@ class Pulp(object):
                           r['id'])
                 continue
 
-            try:
-                r['redirect'] = blob['distributors'][0]['config']['redirect-url']
-            except KeyError:
-                log.debug("no redirect for repo-id %s, using pulp defaults",
-                          r['id'])
+            if blob['distributors']:
+                try:
+                    r['redirect'] = blob['distributors'][0]['config']['redirect-url']
+                except KeyError:
+                    log.debug("no redirect for repo-id %s, using pulp defaults",
+                            r['id'])
+                    r['redirect'] = None
+            else:
                 r['redirect'] = None
 
             if content:


### PR DESCRIPTION
Previously it failed to list repos:

    INFO      getting all repositories...
    Traceback (most recent call last):
    File "/usr/bin/dock-pulp", line 741, in <module>
        main()
    File "/usr/bin/dock-pulp", line 58, in main
        cmd(opts, args[1:])
    File "/usr/bin/dock-pulp", line 406, in do_list
        repos = p.listRepos(content=opts.content)
    File "/usr/lib/python2.6/site-packages/dockpulp/__init__.py", line 573, in listRepos
        r['redirect'] = blob['distributors'][0]['config']['redirect-url']
    IndexError: list index out of range