### PR TITLE
Dock-Pulp confirm for protected repos

### DIFF
--- a/conf/dockpulp.conf
+++ b/conf/dockpulp.conf
@@ -48,7 +48,8 @@ stage = yes
 test = no
 
 # Enter a comma separated list for any distributors in use. Distributors must
-# be defined in /etc/distributors.json. Leave blank if env does not use distributors
+# be defined in /etc/dockpulpdistributors.json. 
+# Leave blank if env does not use distributors
 [distributors]
 prod = docker_export_distributor,docker_web_distributor
 stage = docker_export_distributor,docker_web_distributor


### PR DESCRIPTION
Dock-pulp can now confirm protected repositories, with two caveats.

I had to use subprocess / curl instead of the more preferable python requests because requests does not support encrypted keys. 
Also, the way our entitlements work require the user to be root. What this means for dockpulp is that you'll have to log into the environment as root and run confirm as root for protected repos. 