### PR TITLE
copy_filters: new method, used by recreate-hidden script

### DIFF
--- a/bin/dock-pulp-recreate-hidden.py
+++ b/bin/dock-pulp-recreate-hidden.py
@@ -85,20 +85,18 @@ def recreate(dpo, jfile, test=False):
     for repo in repos:
         if repo['id'] == dockpulp.HIDDEN:
             continue
-        for img in repo['images'].keys():
-            if test:
-                log.info('  Would have copied image %s from %s to hidden repo', img, repo['id'])
-            else:
-                p.copy(dockpulp.HIDDEN, img, source=repo['id'])
+        if test:
+            log.info('  Would have copied images from %s to hidden repo', repo['id'])
+        else:
+            p.copy_filters(dockpulp.HIDDEN, source=repo['id'], v2=False)
 
         # set default in case env has no v2 content
         repo.setdefault('manifests', {})
 
-        for manifest in repo['manifests'].keys():
-            if test:
-                log.info('  Would have copied manifest %s from %s to hidden repo', manifest, repo['id'])
-            else:
-                p.copy(dockpulp.HIDDEN, manifest, source=repo['id'])
+        if test:
+            log.info('  Would have copied manifests from %s to hidden repo', repo['id'])
+        else:
+            p.copy_filters(dockpulp.HIDDEN, source=repo['id'], v1=False)
 
     log.info('Hidden repo recreated.')
 

--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -373,6 +373,30 @@ class Pulp(object):
             data=json.dumps(data))
         self.watch(tid)
 
+    def copy_filters(self, drepo, source=HIDDEN, filters={}, v1=True, v2=True):
+        """Copy an contnet from one repo to another according to filters"""
+
+        type_ids = []
+        if v1:
+            type_ids.append(V1_C_TYPE)
+        if v2:
+            type_ids.extend([V2_C_TYPE, V2_BLOB, V2_TAG])
+        data = {
+            'source_repo_id': source,
+            'criteria': {
+                'type_ids': type_ids,
+                'filters': filters,
+            },
+            'override_config': {}
+        }
+        log.debug('copy request we are sending:')
+        log.debug(pprint.pformat(data))
+        log.info('copying from %s to %s' % (source, drepo))
+        tid = self._post(
+            '/pulp/api/v2/repositories/%s/actions/associate/' % drepo,
+            data=json.dumps(data))
+        self.watch(tid)
+
     """
     """
     def crane(self, repos=[], wait=True, skip=False):


### PR DESCRIPTION
This vastly improves the speed of recreating the hidden repository.