### PR TITLE
get_versions: skip layers if they don't have docker_version set

### DIFF
--- a/dockpulp/imgutils.py
+++ b/dockpulp/imgutils.py
@@ -98,7 +98,8 @@ def get_versions(md):
     vers = {}
     for data in md:
         image_id = data.get('id', data.get('Id'))
-        vers[image_id] = data['docker_version']
+        if 'docker_version' in data.keys():
+            vers[image_id] = data['docker_version']
     return vers
 
 def check_repo(tarfile_path):


### PR DESCRIPTION
Recent docker versions seem to strip docker_version from all layers
except the last one during v1-to-v2 migration. We should ignore layers
that don't have docker_version key