### PR TITLE
Dockpulp checks update redirect-url to fit pulp standards

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -18,6 +18,7 @@ import ConfigParser
 import logging
 import os
 import pprint
+import re
 import requests
 import shutil
 import sys
@@ -1071,6 +1072,10 @@ class Pulp(object):
                         {'image_id': iid, 'tag': tag})
         for key in ('protected', 'redirect-url', 'repo-registry-id'):
             if key in update:
+                if key == 'redirect-url':
+                    if re.match("https?:\/\/.+\/.*", update[key]) is None:
+                        raise errors.DockPulpError('The redirect-url must follow the form '
+                                                   'http://example/url or https://example/url')
                 for distributorkey in delta['distributor_configs']:
                     delta['distributor_configs'][distributorkey][key] = update[key]
         for distributorkey in distributorkeys:


### PR DESCRIPTION
This change is to resolve issue 2661.

Pulp fails silently on redirect-url updates if it does not fit a specific format, so dockpulp now front-ends that check for a better user experience.