### PR TITLE
Added listing label support for v2 manifests

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -797,6 +797,7 @@ class Pulp(object):
                             log.warning("Manifest unreachable, skipping %s", manifest)
                             r['manifests'][manifest]['v1parent'] = None
                             r['manifests'][manifest]['v1id'] = None
+                            r['manifests'][manifest]['v1labels'] = None
                             continue
 
                         # Unsure if all v2 images will have v1 history
@@ -806,6 +807,7 @@ class Pulp(object):
                             log.debug("%s has no v1 history information, skipping", manifest)
                             r['manifests'][manifest]['v1parent'] = None
                             r['manifests'][manifest]['v1id'] = None
+                            r['manifests'][manifest]['v1labels'] = None
                             continue
 
                         try:
@@ -819,6 +821,12 @@ class Pulp(object):
                         except KeyError:
                             log.debug("%s has no v1 history id information", manifest)
                             r['manifests'][manifest]['v1id'] = None
+
+                        try:
+                            r['manifests'][manifest]['v1labels'] = hist['config']['Labels']
+                        except KeyError:
+                            log.debug("%s has no v1 label information", manifest)
+                            r['manifests'][manifest]['v1labels'] = None
 
             clean.append(r)
             clean.sort()

--- a/tests/test_pulp_instance.py
+++ b/tests/test_pulp_instance.py
@@ -4,6 +4,7 @@
 
 from dockpulp import Pulp, RequestsHttpCaller, errors
 import pytest
+import json
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from contextlib import nested
@@ -101,3 +102,28 @@ class TestPulp(object):
             .one_by_one())
         with pytest.raises(errors.DockPulpError):
             pulp.updateRepo(rid, update)
+
+    @pytest.mark.parametrize('repos, content, history', [
+        ('test-repo', True, True),
+        ('test-repo', False, True),
+    ])
+    def test_listHistory(self, pulp, repos, content, history):
+        blob = {'notes': {'_repo-type': 'docker-repo'}, 'id': 'testid', 'description': 'testdesc',
+                'display_name': 'testdisp', 'distributors': [], 'scratchpad': {}}
+        units = [{'unit_type_id': 'docker_manifest',
+                  'metadata': {'fs_layers': [{'blob_sum': 'test'}], 'digest': 'testdig',
+                               'tag': 'testtag'}}]
+        v1Compatibility = {'parent': 'testparent', 'id': 'testid',
+                           'config': {'Labels': {'testlab1': 'testlab2'}}}
+        data = {'history': [{'v1Compatibility': json.dumps(v1Compatibility)}]}
+        flexmock(RequestsHttpCaller)
+        (RequestsHttpCaller
+            .should_receive('__call__')
+            .and_return(blob, units, data)
+            .one_by_one())
+        history = pulp.listRepos(repos, content, history)
+        for key in history[0]['manifests']:
+            assert history[0]['manifests'][key]['v1parent'] == v1Compatibility['parent']
+            assert history[0]['manifests'][key]['v1id'] == v1Compatibility['id']
+            assert history[0]['manifests'][key]['v1labels']['testlab1'] == \
+                v1Compatibility['config']['Labels']['testlab1']


### PR DESCRIPTION
dockpulp list now displays label information for V2.

As far as I can tell, there is no way to obtain label information from Pulp for V1 images.