### PR TITLE
syncRepo: copy new files with an explicit filter

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -2003,8 +2003,19 @@ class Pulp(object):
         # Need to maintain origin repo
         self.createOriginRepo(origin_repo)
 
-        # copy with no filter. Pulp will handle already copied units automatically
-        self.copy_filters(origin_repo, repo)
+        # copy with filter to only select the new units
+        new_units = []
+        filters = {}
+        if imgs:
+            img_ids = {"image_id": {"$in": imgs}}
+            new_units.append(img_ids)
+        if manifests or manifest_lists:
+            digests = [manifest for manifest in manifests]
+            digests.extend([manifest_list for manifest_list in manifest_lists])
+            new_units.append({"manifest_digest": {"$in": digests}})
+        if new_units:
+            filters["unit"] = {"$or": new_units}
+        self.copy_filters(origin_repo, repo, filters)
 
         return (imgs, manifests, manifest_lists)
 


### PR DESCRIPTION
syncRepo: copy new files with an explicit filter
    
apparently pulp does not do a good job of filtering out old files
when copying them to a new repo. In syncRepo, add a filter containing
the new images, new manifests, and new manifest lists.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>