### PR TITLE
Avoid traceback when computing ancestry

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -1691,7 +1691,7 @@ class Pulp(object):
                     parent_id = metadata.setdefault('parent_id', None)
                     if parent_id is None:
                         base_ids.append(image_id)
-                    else:
+                    elif parent_id in imgs:
                         parent_metadata = imgs[parent_id]['metadata']
                         child_ids = parent_metadata.setdefault('child_ids', [])
                         child_ids.append(image_id)


### PR DESCRIPTION
If a repository contains images which are not necessarily strictly
complete in their ancestry, avoid a traceback when computing image
ancestry.

This can be the case for repositories which only hold copies of units
and are never intended to be published.

Signed-off-by: Tim Waugh <twaugh@redhat.com>