### PR TITLE
Separate credentials by server

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -808,8 +808,8 @@ class Pulp(object):
                               ('dist_switchover', "_set_independent_attr", "dist_switchover"),
                               ('switch_ver', "_set_independent_attr", "switch_ver"),
                               ('switch_release', "_set_env_attr", "switch_release"))
-    AUTH_CER_FILE = "pulp.cer"
-    AUTH_KEY_FILE = "pulp.key"
+    AUTH_CER_FILE = "pulp-%s.cer"
+    AUTH_KEY_FILE = "pulp-%s.key"
 
     def __init__(self, env='qa', config_file=DEFAULT_CONFIG_FILE,
                  config_override=None, config_distributors=DEFAULT_DISTRIBUTORS_FILE,
@@ -870,9 +870,9 @@ class Pulp(object):
         for key, cert_path in attrs:
             if self.env == key:
                 self.certificate = os.path.join(os.path.expanduser(cert_path),
-                                                self.AUTH_CER_FILE)
+                                                self.AUTH_CER_FILE % self.env)
                 self.key = os.path.join(os.path.expanduser(cert_path),
-                                        self.AUTH_KEY_FILE)
+                                        self.AUTH_KEY_FILE % self.env)
 
     def _set_independent_attr(self, attrs):
         # set environment independent attributes
@@ -1940,7 +1940,7 @@ class Pulp(object):
             log.info('session info saved in %s' % sessiondir)
             for part in ('certificate', 'key'):
                 # save the cert and key for future calls
-                f = os.path.join(sessiondir, 'pulp.' + part[:3])
+                f = os.path.join(sessiondir, ('pulp-%s.' % self.env) + part[:3])
                 fd = open(f, 'w')
                 fd.write(blob[part])
                 fd.close()

--- a/dockpulp/cli.py
+++ b/dockpulp/cli.py
@@ -104,15 +104,14 @@ def pulp_login(bopts):
         p.key = bopts.key
 
     default_creddir = os.path.expanduser('~/.pulp')
-    if (not p.certificate or not p.key) and\
-        (not os.path.exists(os.path.join(default_creddir, p.AUTH_CER_FILE)) or
-         not os.path.exists(os.path.join(default_creddir, p.AUTH_KEY_FILE))):
+    default_cerfile = os.path.join(default_creddir, p.AUTH_CER_FILE % bopts.server)
+    default_keyfile = os.path.join(default_creddir, p.AUTH_KEY_FILE % bopts.server)
+    if not (p.certificate and p.key) and not \
+       (os.path.exists(default_cerfile) and os.path.exists(default_keyfile)):
         log.error('You need to log in with a user/password first.')
         sys.exit(1)
     else:
-        creddir = os.path.expanduser('~/.pulp')
-        p.set_certs(os.path.join(creddir, p.AUTH_CER_FILE),
-                    os.path.join(creddir, p.AUTH_KEY_FILE))
+        p.set_certs(default_cerfile, default_keyfile)
     return p
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,8 @@ class testPulp(object):
     def __init__(self):
         self.certificate = None
         self.key = None
-        self.AUTH_CER_FILE = ''
-        self.AUTH_KEY_FILE = ''
+        self.AUTH_CER_FILE = '%s'
+        self.AUTH_KEY_FILE = '%s'
 
     def set_certs(self, cert, key):
         return


### PR DESCRIPTION
It's extremely annoying to have to log in each time I switch servers.
Reconciling problems efficiently between environments (especially prod
and stage) results in sensitive passwords being stored in plaintext in
scripts and aliases. This simple patch uses the environment name to
distinguish between credential storage files.