### PR TITLE
Quick fix for Pulp manifest list change

### DIFF
--- a/dockpulp/cli.py
+++ b/dockpulp/cli.py
@@ -532,6 +532,8 @@ def _print_v2_images(repo, showlists, justmanifests, showhistory, showlabels, sh
             if mltags:
                 log.info('    Tags: %s', mltags)
             for manifest in manifest_list_info['mdigests']:
+                if isinstance(manifest, dict):
+                    manifest = manifest['digest']
                 seenmanifests[manifest] = True
                 layers = manifest_layers[manifest]
                 seenlayers[layers] = True


### PR DESCRIPTION
Pulp is now providing a dictionary including arch information instead of a simple string digest, dock-pulp needs to accommodate this.