### PR TITLE
Not wait for tasks in terminal states

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -2404,7 +2404,7 @@ class Pulp(object):
                 log.info('subtask skipped')
                 return t
             elif t['state'] == 'canceled':
-                raise errors.DockPulpError('subtask canceled, please retry')
+                raise errors.DockPulpError('subtask canceled')
             else:
                 log.debug('sleeping (%s/%s seconds passed)' % (curr, timeout))
                 time.sleep(poll)

--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -2400,6 +2400,11 @@ class Pulp(object):
                 log.debug('traceback from subtask:')
                 log.debug(t['traceback'])
                 raise errors.DockPulpTaskError(t['error'])
+            elif t['state'] == 'skipped':
+                log.info('subtask skipped')
+                return t
+            elif t['state'] == 'canceled':
+                raise errors.DockPulpError('subtask canceled, please retry')
             else:
                 log.debug('sleeping (%s/%s seconds passed)' % (curr, timeout))
                 time.sleep(poll)

--- a/tests/test_pulp_instance.py
+++ b/tests/test_pulp_instance.py
@@ -1143,6 +1143,26 @@ class TestPulp(object):
         assert list(manifests) == new_manifests
         assert list(manifest_lists) == new_manifest_lists
 
+    @pytest.mark.parametrize('exception,tid,task', [
+        (errors.DockPulpTaskError, '111', {'state': 'error', 'traceback': 'fake',
+                                           'error': {'code': 'fake'}}),
+        (errors.DockPulpError, '112', {'state': 'canceled'}),
+        ('', '113', {'state': 'skipped'}),
+        ('', '114', {'state': 'finished'}),
+    ])
+    def test_watch(self, pulp, exception, tid, task):
+        flexmock(Pulp)
+        (Pulp
+            .should_receive('getTask')
+            .with_args(tid)
+            .and_return(task))
+        if exception:
+            with pytest.raises(exception):
+                pulp.watch(tid)
+        else:
+            ret = pulp.watch(tid)
+            assert ret == task
+
 
 class TestCrane(object):
     # Tests of methods of Crane class.


### PR DESCRIPTION
Task watch function returns immediately when task is in state
skipped or canceled.