### PR TITLE
Report error when --server isn't specified

### DIFF
--- a/dockpulp/cli.py
+++ b/dockpulp/cli.py
@@ -50,12 +50,14 @@ def main(args=None):
     parser.add_option('-K', '--key', default=False,
                       help='specify a key file, use with -C')
     parser.add_option('-d', '--debug', default=False, action='store_true')
-    parser.add_option('-s', '--server', default='qa',
+    parser.add_option('-s', '--server',
                       help='a Pulp environment to execute against')
     parser.add_option('-c', '--config-file',
                       default=dockpulp.DEFAULT_CONFIG_FILE,
                       help='config file to use [default: %default]')
     opts, args = parser.parse_args(args)
+    if not opts.server:
+        parser.error("Please specify --server.")
     cmd = find_directive('do_', args)
     try:
         cmd(opts, args[1:])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -485,3 +485,9 @@ class TestCLI(object):
                 cli.do_update(bopts, bargs)
         else:
             assert cli.do_update(bopts, bargs) is None
+
+    def test_no_server(self, capsys):
+        with pytest.raises(SystemExit):
+            cli.main(args=['list'])
+        out, err = capsys.readouterr()
+        assert "Please specify --server" in err


### PR DESCRIPTION
'qa' was the default value of server. It could be confusing if it's not noticed. E.g. a user may login to the default environment without specifying --server, but not aware it's 'qa', then get error of 'need to log in' when doing other operations with a --server other than 'qa'. Make --server required to avoid the confusion.