### PR TITLE
Remove update repo metadata functionality

### DIFF
--- a/dockpulp/cli.py
+++ b/dockpulp/cli.py
@@ -996,6 +996,9 @@ def do_update(bopts, bargs, parser):
 
     dock-pulp update [options] repo-id [repo-id...]
     """
+    log.error('Updating repository metadata with dockpulp is no longer supported.')
+    sys.exit(1)
+
     parser.add_option('-d', '--description',
                       help='update the description for this repository')
     parser.add_option('-i', '--dockerid',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -480,11 +480,8 @@ class TestCLI(object):
         bopts = testbOpts()
         p = testPulp()
         mocked_pulp.side_effect = [p]
-        if bargs is None:
-            with pytest.raises(SystemExit):
-                cli.do_update(bopts, bargs)
-        else:
-            assert cli.do_update(bopts, bargs) is None
+        with pytest.raises(SystemExit):
+            cli.do_update(bopts, bargs)
 
     def test_no_server(self, capsys):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
Pulp is no longer the source of truth for repo metadata, so updating
the metadata through dockpulp should no longer be supported

Refers to CLOUDDST-1155